### PR TITLE
Added docker and kubernetes deployer implementations

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,5 +10,13 @@
   "expressions": {
     "URL": "https://github.com/arcalot/arcaflow-expressions",
     "MainBranch": "main"
+  },
+  "deployer-kubernetes": {
+    "URL": "https://github.com/arcalot/arcaflow-engine-deployer-kubernetes",
+    "MainBranch": "main"
+  },
+  "deployer-docker": {
+    "URL": "https://github.com/arcalot/arcaflow-engine-deployer-docker",
+    "MainBranch": "main"
   }
 }

--- a/packages.json
+++ b/packages.json
@@ -11,11 +11,11 @@
     "URL": "https://github.com/arcalot/arcaflow-expressions",
     "MainBranch": "main"
   },
-  "deployer-kubernetes": {
+  "kubernetesdeployer": {
     "URL": "https://github.com/arcalot/arcaflow-engine-deployer-kubernetes",
     "MainBranch": "main"
   },
-  "deployer-docker": {
+  "dockerdeployer": {
     "URL": "https://github.com/arcalot/arcaflow-engine-deployer-docker",
     "MainBranch": "main"
   }


### PR DESCRIPTION
## Changes introduced with this PR


This PR adds the repositories for the kubernetes and docker deployers.
I chose very straightforward names, but they're not the shortest. With the exception of the abbreviation k8s, I don't think any other names would make sense.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).