### PR TITLE
Added test plugin package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -34,5 +34,9 @@
   "testdeployer": {
     "URL": "https://github.com/arcalot/arcaflow-engine-deployer-test-impl",
     "MainBranch": "main"
+  },
+  "testplugin": {
+    "URL": "https://github.com/arcalot/arcaflow-plugin-test-impl-go",
+    "MainBranch": "main"
   }
 }


### PR DESCRIPTION
## Changes introduced with this PR

I believe that this is the appropriate subdomain for the test plugin, which will be used as both a standalone plugin for tests in other arcaflow projects, and directly within the testdeployer.

This plugin is the exception, since it's being used as a library for testing. The other plugins do not need this.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).